### PR TITLE
use sharded log object to avoid lock contention

### DIFF
--- a/include/vector/log_object.h
+++ b/include/vector/log_object.h
@@ -172,8 +172,8 @@ public:
      * @param to_id Sequence ID up to which to truncate (inclusive). If greater
      * than the current tail sequence id it will be clamped to the tail. If less
      * than the current head sequence id the call fails with INVALID_PARAMETER.
-     * If set to UINT64_MAX, the log will be truncated up to the current tail and
-     * updated to_id will be set to the current tail sequence id.
+     * If set to UINT64_MAX, the log will be truncated up to the current tail
+     * and updated to_id will be set to the current tail sequence id.
      * @param log_count Number of log items in the log object after truncation
      * @param txm Transaction execution context (required, non-null)
      * @return LogError::SUCCESS if truncation successful, error code otherwise
@@ -218,17 +218,20 @@ public:
     /**
      * @brief Create multiple sharded log objects
      *
-     * Creates multiple log objects with shard-specific names for high-concurrency
-     * scenarios. Each shard operates independently, allowing parallel writes.
+     * Creates multiple log objects with shard-specific names for
+     * high-concurrency scenarios. Each shard operates independently, allowing
+     * parallel writes.
      *
-     * @param base_log_name Base name for the log objects (e.g., "vector_index:my_index")
+     * @param base_log_name Base name for the log objects (e.g.,
+     * "vector_index:my_index")
      * @param num_shards Number of shards to create (must be > 0)
      * @param txm Transaction execution context (required, non-null)
-     * @return LogError::SUCCESS if all shards created successfully, error code otherwise
+     * @return LogError::SUCCESS if all shards created successfully, error code
+     * otherwise
      */
     static LogError create_sharded_logs(const std::string &base_log_name,
-                                       uint32_t num_shards,
-                                       txservice::TransactionExecution *txm);
+                                        uint32_t num_shards,
+                                        txservice::TransactionExecution *txm);
 
     /**
      * @brief Remove multiple sharded log objects
@@ -239,11 +242,12 @@ public:
      * @param base_log_name Base name for the log objects to remove
      * @param num_shards Number of shards to remove
      * @param txm Transaction execution context (required, non-null)
-     * @return LogError::SUCCESS if all shards removed successfully, error code otherwise
+     * @return LogError::SUCCESS if all shards removed successfully, error code
+     * otherwise
      */
     static LogError remove_sharded_logs(const std::string &base_log_name,
-                                       uint32_t num_shards,
-                                       txservice::TransactionExecution *txm);
+                                        uint32_t num_shards,
+                                        txservice::TransactionExecution *txm);
 
     /**
      * @brief Append log items to a specific shard
@@ -252,7 +256,8 @@ public:
      * shard_key. The shard is selected using hash-based distribution.
      *
      * @param base_log_name Base name for the log objects
-     * @param shard_key Key used to determine which shard to use (e.g., vector ID)
+     * @param shard_key Key used to determine which shard to use (e.g., vector
+     * ID)
      * @param num_shards Total number of shards
      * @param items Log items to append
      * @param log_id Log ID of the last log appended
@@ -261,12 +266,12 @@ public:
      * @return LogError::SUCCESS if append successful, error code otherwise
      */
     static LogError append_log_sharded(const std::string &base_log_name,
-                                      const std::string &shard_key,
-                                      uint32_t num_shards,
-                                      std::vector<log_item_t> &items,
-                                      uint64_t &log_id,
-                                      uint64_t &log_count,
-                                      txservice::TransactionExecution *txm);
+                                       const std::string &shard_key,
+                                       uint32_t num_shards,
+                                       std::vector<log_item_t> &items,
+                                       uint64_t &log_id,
+                                       uint64_t &log_count,
+                                       txservice::TransactionExecution *txm);
 
     /**
      * @brief Truncate all sharded logs
@@ -276,31 +281,16 @@ public:
      *
      * @param base_log_name Base name for the log objects
      * @param num_shards Total number of shards
-     * @param total_log_count Total number of log items across all shards after truncation
+     * @param total_log_count Total number of log items across all shards after
+     * truncation
      * @param txm Transaction execution context (required, non-null)
      * @return LogError::SUCCESS if truncation successful, error code otherwise
      */
-    static LogError truncate_all_sharded_logs(const std::string &base_log_name,
-                                             uint32_t num_shards,
-                                             uint64_t &total_log_count,
-                                             txservice::TransactionExecution *txm);
-
-    /**
-     * @brief Get aggregated statistics for all sharded logs
-     *
-     * Retrieves aggregated statistics about all sharded log objects including
-     * total items, sequence ID ranges, and total size across all shards.
-     *
-     * @param base_log_name Base name for the log objects
-     * @param num_shards Total number of shards
-     * @param aggregated_stats Output aggregated metadata across all shards
-     * @param txm Transaction execution context (required, non-null)
-     * @return LogError::SUCCESS if stats retrieval successful, error code otherwise
-     */
-    static LogError get_sharded_log_stats(const std::string &base_log_name,
-                                         uint32_t num_shards,
-                                         log_metadata_t &aggregated_stats,
-                                         txservice::TransactionExecution *txm);
+    static LogError truncate_all_sharded_logs(
+        const std::string &base_log_name,
+        uint32_t num_shards,
+        uint64_t &total_log_count,
+        txservice::TransactionExecution *txm);
 
 private:
     /**
@@ -368,18 +358,21 @@ private:
      * @param num_shards Total number of shards
      * @return Shard ID (0 to num_shards-1)
      */
-    static uint32_t get_shard_id(const std::string &shard_key, uint32_t num_shards);
+    static uint32_t get_shard_id(const std::string &shard_key,
+                                 uint32_t num_shards);
 
     /**
      * @brief Get shard-specific log name
      *
-     * Generates the log name for a specific shard based on base name and shard ID.
+     * Generates the log name for a specific shard based on base name and shard
+     * ID.
      *
      * @param base_log_name Base name for the log objects
      * @param shard_id Shard ID (0 to num_shards-1)
      * @return Shard-specific log name
      */
-    static std::string get_shard_log_name(const std::string &base_log_name, uint32_t shard_id);
+    static std::string get_shard_log_name(const std::string &base_log_name,
+                                          uint32_t shard_id);
 };
 
 }  // namespace EloqVec

--- a/include/vector/log_object.h
+++ b/include/vector/log_object.h
@@ -213,6 +213,95 @@ public:
     static log_metadata_t get_stats(const std::string &log_name,
                                     txservice::TransactionExecution *txm);
 
+    // ===== SHARDED LOG APIs =====
+
+    /**
+     * @brief Create multiple sharded log objects
+     *
+     * Creates multiple log objects with shard-specific names for high-concurrency
+     * scenarios. Each shard operates independently, allowing parallel writes.
+     *
+     * @param base_log_name Base name for the log objects (e.g., "vector_index:my_index")
+     * @param num_shards Number of shards to create (must be > 0)
+     * @param txm Transaction execution context (required, non-null)
+     * @return LogError::SUCCESS if all shards created successfully, error code otherwise
+     */
+    static LogError create_sharded_logs(const std::string &base_log_name,
+                                       uint32_t num_shards,
+                                       txservice::TransactionExecution *txm);
+
+    /**
+     * @brief Remove multiple sharded log objects
+     *
+     * Removes all sharded log objects including metadata and all associated
+     * log items. This operation is irreversible.
+     *
+     * @param base_log_name Base name for the log objects to remove
+     * @param num_shards Number of shards to remove
+     * @param txm Transaction execution context (required, non-null)
+     * @return LogError::SUCCESS if all shards removed successfully, error code otherwise
+     */
+    static LogError remove_sharded_logs(const std::string &base_log_name,
+                                       uint32_t num_shards,
+                                       txservice::TransactionExecution *txm);
+
+    /**
+     * @brief Append log items to a specific shard
+     *
+     * Adds new log items to the end of a specific shard determined by the
+     * shard_key. The shard is selected using hash-based distribution.
+     *
+     * @param base_log_name Base name for the log objects
+     * @param shard_key Key used to determine which shard to use (e.g., vector ID)
+     * @param num_shards Total number of shards
+     * @param items Log items to append
+     * @param log_id Log ID of the last log appended
+     * @param log_count Number of log items in the target shard after appending
+     * @param txm Transaction execution context (required, non-null)
+     * @return LogError::SUCCESS if append successful, error code otherwise
+     */
+    static LogError append_log_sharded(const std::string &base_log_name,
+                                      const std::string &shard_key,
+                                      uint32_t num_shards,
+                                      std::vector<log_item_t> &items,
+                                      uint64_t &log_id,
+                                      uint64_t &log_count,
+                                      txservice::TransactionExecution *txm);
+
+    /**
+     * @brief Truncate all sharded logs
+     *
+     * Removes all log items from all shards.
+     * This operation is used for log cleanup and maintenance across all shards.
+     *
+     * @param base_log_name Base name for the log objects
+     * @param num_shards Total number of shards
+     * @param total_log_count Total number of log items across all shards after truncation
+     * @param txm Transaction execution context (required, non-null)
+     * @return LogError::SUCCESS if truncation successful, error code otherwise
+     */
+    static LogError truncate_all_sharded_logs(const std::string &base_log_name,
+                                             uint32_t num_shards,
+                                             uint64_t &total_log_count,
+                                             txservice::TransactionExecution *txm);
+
+    /**
+     * @brief Get aggregated statistics for all sharded logs
+     *
+     * Retrieves aggregated statistics about all sharded log objects including
+     * total items, sequence ID ranges, and total size across all shards.
+     *
+     * @param base_log_name Base name for the log objects
+     * @param num_shards Total number of shards
+     * @param aggregated_stats Output aggregated metadata across all shards
+     * @param txm Transaction execution context (required, non-null)
+     * @return LogError::SUCCESS if stats retrieval successful, error code otherwise
+     */
+    static LogError get_sharded_log_stats(const std::string &base_log_name,
+                                         uint32_t num_shards,
+                                         log_metadata_t &aggregated_stats,
+                                         txservice::TransactionExecution *txm);
+
 private:
     /**
      * @brief Serialize metadata to string
@@ -267,6 +356,30 @@ private:
      */
     static std::string get_log_item_key(const std::string &log_name,
                                         uint64_t sequence_id);
+
+    // ===== SHARDED LOG HELPER FUNCTIONS =====
+
+    /**
+     * @brief Get shard ID for a given shard key
+     *
+     * Uses hash-based distribution to determine which shard a key belongs to.
+     *
+     * @param shard_key Key used to determine shard (e.g., vector ID)
+     * @param num_shards Total number of shards
+     * @return Shard ID (0 to num_shards-1)
+     */
+    static uint32_t get_shard_id(const std::string &shard_key, uint32_t num_shards);
+
+    /**
+     * @brief Get shard-specific log name
+     *
+     * Generates the log name for a specific shard based on base name and shard ID.
+     *
+     * @param base_log_name Base name for the log objects
+     * @param shard_id Shard ID (0 to num_shards-1)
+     * @return Shard-specific log name
+     */
+    static std::string get_shard_log_name(const std::string &base_log_name, uint32_t shard_id);
 };
 
 }  // namespace EloqVec

--- a/include/vector/vector_handler.h
+++ b/include/vector/vector_handler.h
@@ -65,11 +65,6 @@ public:
         return alg_params_;
     }
 
-    size_t Size() const
-    {
-        return size_;
-    }
-
     uint64_t CreatedTs() const
     {
         return created_ts_;
@@ -113,8 +108,6 @@ private:
     std::unordered_map<std::string, std::string> alg_params_;
     std::string file_path_{""};
     size_t buffer_threshold_{10000};
-    // Total number of vectors in the index
-    size_t size_{0};
     uint64_t created_ts_{0};
     uint64_t last_persist_ts_{0};
 };

--- a/include/vector/vector_handler.h
+++ b/include/vector/vector_handler.h
@@ -90,16 +90,6 @@ public:
         return file_path_;
     }
 
-    uint64_t LastPersistedSequenceId() const
-    {
-        return last_persisted_sequence_id_;
-    }
-
-    void SetLastPersistedSequenceId(uint64_t seq_id)
-    {
-        last_persisted_sequence_id_ = seq_id;
-    }
-
     void SetFilePath(const std::string &path)
     {
         file_path_ = path;
@@ -127,8 +117,6 @@ private:
     size_t size_{0};
     uint64_t created_ts_{0};
     uint64_t last_persist_ts_{0};
-    // Persistence tracking fields
-    uint64_t last_persisted_sequence_id_{0};
 };
 
 /**

--- a/src/vector/log_object.cpp
+++ b/src/vector/log_object.cpp
@@ -190,17 +190,31 @@ std::string LogObject::get_log_item_key(const std::string &log_name,
 
 // ===== SHARDED LOG HELPER FUNCTIONS =====
 
-uint32_t LogObject::get_shard_id(const std::string &shard_key, uint32_t num_shards)
+uint32_t LogObject::get_shard_id(const std::string &shard_key,
+                                 uint32_t num_shards)
 {
-    if (num_shards == 0) {
+    if (num_shards == 0)
+    {
         return 0;  // Avoid division by zero
     }
-    
-    std::hash<std::string> hasher;
-    return hasher(shard_key) % num_shards;
+
+    // FNV-1a hash implementation for stable 64-bit hashing
+    const uint64_t fnv_offset_basis = 14695981039346656037ULL;
+    const uint64_t fnv_prime = 1099511628211ULL;
+
+    uint64_t fnv64_hash = fnv_offset_basis;
+    for (char c : shard_key)
+    {
+        fnv64_hash ^= static_cast<uint8_t>(c);
+        fnv64_hash *= fnv_prime;
+    }
+
+    return static_cast<uint32_t>(fnv64_hash %
+                                 static_cast<uint64_t>(num_shards));
 }
 
-std::string LogObject::get_shard_log_name(const std::string &base_log_name, uint32_t shard_id)
+std::string LogObject::get_shard_log_name(const std::string &base_log_name,
+                                          uint32_t shard_id)
 {
     return base_log_name + ":shard_" + std::to_string(shard_id);
 }
@@ -957,8 +971,8 @@ log_metadata_t LogObject::get_stats(const std::string &log_name,
 // ===== SHARDED LOG IMPLEMENTATIONS =====
 
 LogError LogObject::create_sharded_logs(const std::string &base_log_name,
-                                       uint32_t num_shards,
-                                       txservice::TransactionExecution *txm)
+                                        uint32_t num_shards,
+                                        txservice::TransactionExecution *txm)
 {
     // Require non-null transaction execution context
     if (txm == nullptr)
@@ -972,10 +986,11 @@ LogError LogObject::create_sharded_logs(const std::string &base_log_name,
         return LogError::INVALID_PARAMETER;
     }
 
-    // Create all shard logs in parallel within transaction
+    // Create all shard logs sequentially within transaction
     for (uint32_t shard_id = 0; shard_id < num_shards; ++shard_id)
     {
-        std::string shard_log_name = get_shard_log_name(base_log_name, shard_id);
+        std::string shard_log_name =
+            get_shard_log_name(base_log_name, shard_id);
         LogError result = create_log(shard_log_name, txm);
         if (result != LogError::SUCCESS)
         {
@@ -987,8 +1002,8 @@ LogError LogObject::create_sharded_logs(const std::string &base_log_name,
 }
 
 LogError LogObject::remove_sharded_logs(const std::string &base_log_name,
-                                       uint32_t num_shards,
-                                       txservice::TransactionExecution *txm)
+                                        uint32_t num_shards,
+                                        txservice::TransactionExecution *txm)
 {
     // Require non-null transaction execution context
     if (txm == nullptr)
@@ -1002,10 +1017,11 @@ LogError LogObject::remove_sharded_logs(const std::string &base_log_name,
         return LogError::INVALID_PARAMETER;
     }
 
-    // Remove all shard logs in parallel within transaction
+    // Remove all shard logs sequentially within transaction
     for (uint32_t shard_id = 0; shard_id < num_shards; ++shard_id)
     {
-        std::string shard_log_name = get_shard_log_name(base_log_name, shard_id);
+        std::string shard_log_name =
+            get_shard_log_name(base_log_name, shard_id);
         LogError result = remove_log(shard_log_name, txm);
         if (result != LogError::SUCCESS)
         {
@@ -1017,12 +1033,12 @@ LogError LogObject::remove_sharded_logs(const std::string &base_log_name,
 }
 
 LogError LogObject::append_log_sharded(const std::string &base_log_name,
-                                      const std::string &shard_key,
-                                      uint32_t num_shards,
-                                      std::vector<log_item_t> &items,
-                                      uint64_t &log_id,
-                                      uint64_t &log_count,
-                                      txservice::TransactionExecution *txm)
+                                       const std::string &shard_key,
+                                       uint32_t num_shards,
+                                       std::vector<log_item_t> &items,
+                                       uint64_t &log_id,
+                                       uint64_t &log_count,
+                                       txservice::TransactionExecution *txm)
 {
     // Require non-null transaction execution context
     if (txm == nullptr)
@@ -1044,10 +1060,11 @@ LogError LogObject::append_log_sharded(const std::string &base_log_name,
     return append_log(shard_log_name, items, log_id, log_count, txm);
 }
 
-LogError LogObject::truncate_all_sharded_logs(const std::string &base_log_name,
-                                             uint32_t num_shards,
-                                             uint64_t &total_log_count,
-                                             txservice::TransactionExecution *txm)
+LogError LogObject::truncate_all_sharded_logs(
+    const std::string &base_log_name,
+    uint32_t num_shards,
+    uint64_t &total_log_count,
+    txservice::TransactionExecution *txm)
 {
     // Require non-null transaction execution context
     if (txm == nullptr)
@@ -1063,71 +1080,22 @@ LogError LogObject::truncate_all_sharded_logs(const std::string &base_log_name,
 
     total_log_count = 0;
 
-    // Truncate all shards in parallel within transaction
+    // Truncate all shards sequentially within transaction
     for (uint32_t shard_id = 0; shard_id < num_shards; ++shard_id)
     {
-        std::string shard_log_name = get_shard_log_name(base_log_name, shard_id);
+        std::string shard_log_name =
+            get_shard_log_name(base_log_name, shard_id);
         uint64_t shard_log_count = 0;
         uint64_t shard_to_id = UINT64_MAX;
 
-        LogError result = truncate_log(shard_log_name, shard_to_id, shard_log_count, txm);
+        LogError result =
+            truncate_log(shard_log_name, shard_to_id, shard_log_count, txm);
         if (result != LogError::SUCCESS)
         {
             return result;
         }
 
         total_log_count += shard_log_count;
-    }
-
-    return LogError::SUCCESS;
-}
-
-LogError LogObject::get_sharded_log_stats(const std::string &base_log_name,
-                                         uint32_t num_shards,
-                                         log_metadata_t &aggregated_stats,
-                                         txservice::TransactionExecution *txm)
-{
-    // Require non-null transaction execution context
-    if (txm == nullptr)
-    {
-        return LogError::INVALID_PARAMETER;
-    }
-
-    // Validate parameters
-    if (num_shards == 0)
-    {
-        return LogError::INVALID_PARAMETER;
-    }
-
-    // Initialize aggregated stats
-    aggregated_stats = log_metadata_t();
-
-    // Collect stats from all shards
-    for (uint32_t shard_id = 0; shard_id < num_shards; ++shard_id)
-    {
-        std::string shard_log_name = get_shard_log_name(base_log_name, shard_id);
-        log_metadata_t shard_stats = get_stats(shard_log_name, txm);
-
-        // Aggregate statistics
-        aggregated_stats.total_items += shard_stats.total_items;
-        
-        // Update head sequence ID (minimum across all shards)
-        if (shard_id == 0 || shard_stats.head_item_sequence_id < aggregated_stats.head_item_sequence_id)
-        {
-            aggregated_stats.head_item_sequence_id = shard_stats.head_item_sequence_id;
-        }
-        
-        // Update tail sequence ID (maximum across all shards)
-        if (shard_stats.tail_item_sequence_id > aggregated_stats.tail_item_sequence_id)
-        {
-            aggregated_stats.tail_item_sequence_id = shard_stats.tail_item_sequence_id;
-        }
-        
-        // Update next ID (maximum across all shards)
-        if (shard_stats.next_id > aggregated_stats.next_id)
-        {
-            aggregated_stats.next_id = shard_stats.next_id;
-        }
     }
 
     return LogError::SUCCESS;

--- a/src/vector/vector_handler.cpp
+++ b/src/vector/vector_handler.cpp
@@ -94,7 +94,7 @@ void VectorMetadata::Encode(std::string &encoded_str) const
      * The format of the encoded metadata:
      * nameLen | name | dimension | algorithm | metric | paramCount | key1Len |
      * key1 | value1Len | value1 | ... | filePathLen | filePath |
-     * bufferThreshold | size | createdTs | lastPersistTs
+     * bufferThreshold | createdTs | lastPersistTs
      * 1. nameLen is a 2-byte integer representing the length of the name. 2.
      * name is a string. 3. dimension is a 8-byte integer representing the
      * dimension. 4. algorithm is a 1-byte integer representing the
@@ -104,9 +104,8 @@ void VectorMetadata::Encode(std::string &encoded_str) const
      * valueLen (4-byte) | value (string). 8. filePathLen is a 4-byte integer
      * representing the length of the file path. 9. filePath is a string. 10.
      * bufferThreshold is a 8-byte integer representing the buffer
-     * threshold. 11. size is a 8-byte integer representing the size of the
-     * index. 12. createdTs is a 8-byte integer representing the creation
-     * timestamp. 13. lastPersistTs is a 8-byte integer representing the last
+     * threshold. 11. createdTs is a 8-byte integer representing the creation
+     * timestamp. 12. lastPersistTs is a 8-byte integer representing the last
      * persist timestamp.
      */
     uint16_t name_len = static_cast<uint16_t>(name_.size());
@@ -159,10 +158,6 @@ void VectorMetadata::Encode(std::string &encoded_str) const
 
     len_sizeof = sizeof(size_t);
     val_ptr = reinterpret_cast<const char *>(&buffer_threshold_);
-    encoded_str.append(val_ptr, len_sizeof);
-
-    len_sizeof = sizeof(size_t);
-    val_ptr = reinterpret_cast<const char *>(&size_);
     encoded_str.append(val_ptr, len_sizeof);
 
     len_sizeof = sizeof(uint64_t);
@@ -231,9 +226,6 @@ void VectorMetadata::Decode(const char *buf,
     offset += file_path_len;
 
     buffer_threshold_ = *reinterpret_cast<const size_t *>(buf + offset);
-    offset += sizeof(size_t);
-
-    size_ = *reinterpret_cast<const size_t *>(buf + offset);
     offset += sizeof(size_t);
 
     created_ts_ = *reinterpret_cast<const uint64_t *>(buf + offset);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds sharded logging for vector indexes: create/remove shards, sharded appends, truncate across all shards, and aggregated shard stats.

- Improvements
  - Index persistence and lifecycle now operate across shards with updated metadata encoding and streamlined persistence flow.

- Breaking Changes
  - Single-log APIs replaced by sharded equivalents.
  - Persisted sequence ID removed from vector metadata; related accessors and serialization are no longer supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->