### PR TITLE
Add get interface for vector index

### DIFF
--- a/include/vector/hnsw_vector_index.h
+++ b/include/vector/hnsw_vector_index.h
@@ -62,6 +62,7 @@ public:
     IndexOpResult remove(uint64_t id) override;
     IndexOpResult update(const std::vector<float> &vector,
                          uint64_t id) override;
+    IndexOpResult get(uint64_t id, std::vector<float> &vector) override;
     size_t memory_usage() override;
     bool is_ready() override;
     size_t get_dimension() override;

--- a/include/vector/vector_index.h
+++ b/include/vector/vector_index.h
@@ -72,10 +72,11 @@ public:
      *
      * @param query_vector The query vector to search for
      * @param k Number of nearest neighbors to return
-     * @param result SearchResult containing IDs, distances, and optionally vectors
+     * @param result SearchResult containing IDs, distances, and optionally
+     * vectors
      * @param exact Whether to return exact matches
      * @param filter Optional filter function to apply to results
-     * @return IndexOpResult 
+     * @return IndexOpResult
      */
     virtual IndexOpResult search(
         const std::vector<float> &query_vector,
@@ -91,7 +92,8 @@ public:
      * @param id Unique identifier for the vector
      * @return IndexOpResult
      */
-    virtual IndexOpResult add(const std::vector<float> &vector, uint64_t id) = 0;
+    virtual IndexOpResult add(const std::vector<float> &vector,
+                              uint64_t id) = 0;
 
     /**
      * @brief Add multiple vectors to the index in batch
@@ -100,8 +102,9 @@ public:
      * @param ids Vector of unique identifiers
      * @return IndexOpResult
      */
-    virtual IndexOpResult add_batch(const std::vector<std::vector<float>> &vectors,
-                           const std::vector<uint64_t> &ids) = 0;
+    virtual IndexOpResult add_batch(
+        const std::vector<std::vector<float>> &vectors,
+        const std::vector<uint64_t> &ids) = 0;
 
     /**
      * @brief Delete a vector from the index
@@ -118,7 +121,18 @@ public:
      * @param id Unique identifier of the vector to update
      * @return IndexOpResult
      */
-    virtual IndexOpResult update(const std::vector<float> &vector, uint64_t id) = 0;
+    virtual IndexOpResult update(const std::vector<float> &vector,
+                                 uint64_t id) = 0;
+
+    /**
+     * @brief Get a vector from the index
+     *
+     * @param id Unique identifier of the vector to get
+     * @param vector [OUT] The vector data. If the size of the vector is 0, it
+     * means that no such @id exists in the index.
+     * @return IndexOpResult
+     */
+    virtual IndexOpResult get(uint64_t id, std::vector<float> &vector) = 0;
 
     /**
      * @brief Get the current memory usage of the index

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -19967,7 +19967,7 @@ void InfoVecIndexCommand::OutputResult(OutputHandler *reply,
     {
         // For now, return a simple placeholder response
         auto &alg_params = metadata_.VecAlgParams();
-        size_t len = (7 + alg_params.size()) * 2;
+        size_t len = (6 + alg_params.size()) * 2;
         reply->OnArrayStart(len);
         reply->OnString("index_name");
         reply->OnString(index_name_.StringView());
@@ -19984,8 +19984,6 @@ void InfoVecIndexCommand::OutputResult(OutputHandler *reply,
             reply->OnString(param.first);
             reply->OnString(param.second);
         }
-        reply->OnString("size");
-        reply->OnString(std::to_string(metadata_.Size()));
         reply->OnString("created_ts");
         reply->OnString(std::to_string(metadata_.CreatedTs()));
         reply->OnString("last_persist_ts");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vector indexes now support retrieving stored vectors by their ID.

* **Chores**
  * Updated info command output: removed the “size” field and adjusted the reported array length, resulting in a different field count/structure in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->